### PR TITLE
Handle failures better

### DIFF
--- a/custom_components/knmi/__init__.py
+++ b/custom_components/knmi/__init__.py
@@ -9,7 +9,7 @@ from datetime import timedelta
 import logging
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME, CONF_API_KEY
+from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_API_KEY
 from homeassistant.core import Config, HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession

--- a/custom_components/knmi/api.py
+++ b/custom_components/knmi/api.py
@@ -38,6 +38,9 @@ class KnmiApiClient:
                     if "Vraag eerst een API-key op" in await response.text():
                         raise KnmiApiKeyException("Invalid API key")
 
+                    if "Dagelijkse limiet" in await response.text():
+                        raise KnmiApiKeyException("Exceeded Daily Limit")
+
                     data = await response.json()
                     return data.get("liveweer")[0]
 
@@ -61,7 +64,7 @@ class KnmiApiClient:
                 exception,
             )
         except KnmiApiKeyException as exception:
-            _LOGGER.error("Error with configuration! - %s", exception)
+            _LOGGER.error("Error in API! - %s", exception)
             # Raise to pass on to the user.
             raise exception
         except Exception as exception:  # pylint: disable=broad-except

--- a/custom_components/knmi/binary_sensor.py
+++ b/custom_components/knmi/binary_sensor.py
@@ -1,5 +1,6 @@
 """Binary sensor platform for knmi."""
 from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.const import CONF_NAME
 
 from .const import (
     BINARY_SENSORS,
@@ -43,8 +44,7 @@ class KnmiBinarySensor(KnmiEntity, BinarySensorEntity):
         data_key,
     ):
         super().__init__(coordinator, config_entry)
-        self.config_entry = config_entry
-        self.location_name = self.coordinator.data["plaats"]
+        self.entry_name = config_entry.data.get(CONF_NAME)
         self._name = name
         self._icon = icon
         self._device_class = device_class
@@ -54,12 +54,13 @@ class KnmiBinarySensor(KnmiEntity, BinarySensorEntity):
     @property
     def name(self):
         """Return the name of the binary_sensor."""
-        return f"{DEFAULT_NAME} {self.location_name} {self._name}"
+        return f"{DEFAULT_NAME} {self.entry_name} {self._name}"
 
     @property
     def is_on(self):
         """Return true if the binary_sensor is on."""
-        return self.coordinator.data[self._data_key] != "0"
+        if super().getData(self._data_key) is not None:
+            return super().getData(self._data_key) != "0"
 
     @property
     def icon(self):
@@ -78,7 +79,7 @@ class KnmiBinarySensor(KnmiEntity, BinarySensorEntity):
         for attribute in self._attributes:
             value = None
             if "key" in attribute:
-                value = self.coordinator.data[attribute.get("key", None)]
+                value = super().getData(attribute.get("key", None))
             if "value" in attribute:
                 value = attribute.get("value", None)
             attributes[attribute.get("name", None)] = value

--- a/custom_components/knmi/const.py
+++ b/custom_components/knmi/const.py
@@ -26,7 +26,7 @@ MEASUREMENT = "measurement"
 # Base component constants.
 NAME = "KNMI"
 DOMAIN = "knmi"
-VERSION = "1.1.4"
+VERSION = "1.1.5"
 ATTRIBUTION = "KNMI Weergegevens via https://weerlive.nl/"
 
 # Platforms.

--- a/custom_components/knmi/entity.py
+++ b/custom_components/knmi/entity.py
@@ -8,7 +8,14 @@ from .const import DOMAIN, NAME, VERSION, ATTRIBUTION
 class KnmiEntity(CoordinatorEntity):
     def __init__(self, coordinator, config_entry):
         super().__init__(coordinator)
+        self.coordinator = coordinator
         self.config_entry = config_entry
+
+    def getData(self, key):
+        """Return the data key from the coordinator."""
+        if self.coordinator.data is not None:
+            return self.coordinator.data[key]
+        return None
 
     @property
     def unique_id(self):

--- a/custom_components/knmi/manifest.json
+++ b/custom_components/knmi/manifest.json
@@ -4,7 +4,7 @@
   "documentation": "https://github.com/golles/ha-knmi/",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/golles/ha-knmi//issues",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "config_flow": true,
   "codeowners": [
     "@golles"

--- a/custom_components/knmi/sensor.py
+++ b/custom_components/knmi/sensor.py
@@ -1,4 +1,5 @@
 """Sensor platform for knmi."""
+from homeassistant.const import CONF_NAME
 from .const import DEFAULT_NAME, DOMAIN, SENSORS
 from .entity import KnmiEntity
 
@@ -40,8 +41,7 @@ class KnmiSensor(KnmiEntity):
         data_key,
     ):
         super().__init__(coordinator, config_entry)
-        self.config_entry = config_entry
-        self.location_name = self.coordinator.data["plaats"]
+        self.entry_name = config_entry.data.get(CONF_NAME)
         self._name = name
         self._unit_of_measurement = unit_of_measurement
         self._icon = icon
@@ -52,12 +52,12 @@ class KnmiSensor(KnmiEntity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return f"{DEFAULT_NAME} {self.location_name} {self._name}"
+        return f"{DEFAULT_NAME} {self.entry_name} {self._name}"
 
     @property
     def state(self):
         """Return the state of the sensor."""
-        return self.coordinator.data[self._data_key]
+        return super().getData(self._data_key)
 
     @property
     def unit_of_measurement(self):
@@ -81,7 +81,7 @@ class KnmiSensor(KnmiEntity):
         for attribute in self._attributes:
             value = None
             if "key" in attribute:
-                value = self.coordinator.data[attribute.get("key", None)]
+                value = super().getData(attribute.get("key", None))
             if "value" in attribute:
                 value = attribute.get("value", None)
             attributes[attribute.get("name", None)] = value


### PR DESCRIPTION
Should prevent the issue reported in #7 

Sensors will report unavailable when there is something wrong with the API (timeout, daily limit reached etc)
<img width="333" alt="ua" src="https://user-images.githubusercontent.com/2211503/147297342-459d2717-13f0-4519-b77e-d1a57c2d117b.png">

And the sensors should restore once data is being retrieved again.

# Local test
Api was failing due to exceeding limits, when the new day started, sensors restored
Log:
```text
2021-12-23 22:57:58 ERROR (MainThread) [custom_components.knmi] Error in API! - Exceeded Daily Limit
2021-12-23 22:57:58 ERROR (MainThread) [custom_components.knmi] Error fetching knmi data: 
2021-12-23 22:57:58 DEBUG (MainThread) [custom_components.knmi] Finished fetching knmi data in 0.059 seconds (success: False)
2021-12-23 22:59:18 ERROR (MainThread) [custom_components.knmi] Error in API! - Exceeded Daily Limit
2021-12-23 22:59:18 ERROR (MainThread) [custom_components.knmi] Error fetching knmi data: 
2021-12-23 22:59:18 DEBUG (MainThread) [custom_components.knmi] Finished fetching knmi data in 0.050 seconds (success: False)
2021-12-23 23:00:38 DEBUG (MainThread) [custom_components.knmi] Finished fetching knmi data in 0.083 seconds (success: True)
2021-12-23 23:00:38 INFO (MainThread) [homeassistant.components.binary_sensor] Setting up binary_sensor.knmi
2021-12-23 23:00:38 INFO (MainThread) [homeassistant.components.sensor] Setting up sensor.knmi
2021-12-23 23:00:38 INFO (SyncWorker_0) [homeassistant.loader] Loaded weather from homeassistant.components.weather
2021-12-23 23:00:38 INFO (MainThread) [homeassistant.setup] Setting up weather
2021-12-23 23:00:38 INFO (MainThread) [homeassistant.setup] Setup of domain weather took 0.0 seconds
2021-12-23 23:00:38 INFO (MainThread) [homeassistant.components.weather] Setting up weather.knmi
```
Result:
<img width="327" alt="r" src="https://user-images.githubusercontent.com/2211503/147298115-8616c951-7dd1-458d-8942-ccd3c1349161.png">

