### PR TITLE
Fix: Forecast precipitation to precipitation probability

### DIFF
--- a/custom_components/knmi/weather.py
+++ b/custom_components/knmi/weather.py
@@ -7,7 +7,7 @@ from homeassistant.components.weather import (
     ATTR_FORECAST_TEMP,
     ATTR_FORECAST_TEMP_LOW,
     ATTR_FORECAST_TIME,
-    ATTR_FORECAST_PRECIPITATION,
+    ATTR_FORECAST_PRECIPITATION_PROBABILITY,
     ATTR_FORECAST_WIND_BEARING,
     ATTR_FORECAST_WIND_SPEED,
     WeatherEntity,
@@ -119,7 +119,7 @@ class KnmiWeather(KnmiEntity, WeatherEntity):
                 if super().getData(f"d{i}tmax") is not None
                 else None
             )
-            precipitation = (
+            precipitation_probability = (
                 float(super().getData(f"d{i}neerslag"))
                 if super().getData(f"d{i}neerslag") is not None
                 else None
@@ -139,7 +139,7 @@ class KnmiWeather(KnmiEntity, WeatherEntity):
                 ATTR_FORECAST_CONDITION: condition,
                 ATTR_FORECAST_TEMP_LOW: temp_low,
                 ATTR_FORECAST_TEMP: temp,
-                ATTR_FORECAST_PRECIPITATION: precipitation,
+                ATTR_FORECAST_PRECIPITATION_PROBABILITY: precipitation_probability,
                 ATTR_FORECAST_WIND_BEARING: wind_bearing,
                 ATTR_FORECAST_WIND_SPEED: wind_speed,
                 "sun_chance": sun_chance,

--- a/hacs.json
+++ b/hacs.json
@@ -1,10 +1,5 @@
 {
     "name": "knmi",
-    "hacs": "1.6.0",
-    "domains": [
-        "binary_sensor",
-        "sensor",
-        "switch"
-    ],
-    "homeassistant": "0.118.0"
+    "homeassistant": "2022.2.0",
+    "render_readme": true
 }


### PR DESCRIPTION
After reading the documentation, https://developers.home-assistant.io/docs/core/entity/weather/
I realized I mixed up `precipitation` and `precipitation_probability` in the forecast.

Addresses #22 