### PR TITLE
Correctly map `regen` and `buien` from API to HA

### DIFF
--- a/custom_components/knmi/weather.py
+++ b/custom_components/knmi/weather.py
@@ -45,8 +45,8 @@ _LOGGER: logging.Logger = logging.getLogger(__package__)
 CONDITIONS_MAP = {
     "zonnig": ATTR_CONDITION_SUNNY,
     "bliksem": ATTR_CONDITION_LIGHTNING,
-    "regen": ATTR_CONDITION_RAINY,
-    "buien": ATTR_CONDITION_POURING,
+    "regen": ATTR_CONDITION_POURING,
+    "buien": ATTR_CONDITION_RAINY,
     "hagel": ATTR_CONDITION_HAIL,
     "mist": ATTR_CONDITION_FOG,
     "sneeuw": ATTR_CONDITION_SNOWY,

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -77,8 +77,8 @@ async def test_map_conditions(hass, bypass_get_data, caplog):
     # Documented conditions.
     map_condition(weather, "zonnig", ATTR_CONDITION_SUNNY)
     map_condition(weather, "bliksem", ATTR_CONDITION_LIGHTNING)
-    map_condition(weather, "regen", ATTR_CONDITION_RAINY)
-    map_condition(weather, "buien", ATTR_CONDITION_POURING)
+    map_condition(weather, "regen", ATTR_CONDITION_POURING)
+    map_condition(weather, "buien", ATTR_CONDITION_RAINY)
     map_condition(weather, "hagel", ATTR_CONDITION_HAIL)
     map_condition(weather, "mist", ATTR_CONDITION_FOG)
     map_condition(weather, "sneeuw", ATTR_CONDITION_SNOWY)


### PR DESCRIPTION
From a discussion started on [tweakers](https://gathering.tweakers.net/forum/list_message/73819698#73819698), following the definition from the KNMI website https://www.knmi.nl/kennis-en-datacentrum/uitleg/buien