### PR TITLE
Don't specify icon for warning sensor

### DIFF
--- a/custom_components/knmi/binary_sensor.py
+++ b/custom_components/knmi/binary_sensor.py
@@ -40,7 +40,6 @@ async def async_setup_entry(
                 description=SensorEntityDescription(
                     key="alarm",
                     name="Waarschuwing",
-                    icon="mdi:alert",
                     device_class=BinarySensorDeviceClass.SAFETY,
                 ),
             ),


### PR DESCRIPTION
This will let HA change the icon to be defined based on the state