### PR TITLE
Improved log warning when a value is empty

### DIFF
--- a/custom_components/knmi/coordinator.py
+++ b/custom_components/knmi/coordinator.py
@@ -42,6 +42,10 @@ class KnmiDataUpdateCoordinator(DataUpdateCoordinator):
     ) -> float | int | str | None:
         """Get a value from the retrieved data and convert to given type"""
         if self.data and key in self.data:
+            if self.data.get(key, None) == "":
+                _LOGGER.warning("Value %s is empty in API response", key)
+                return ""  # Leave empty, eg. warning attribute can be an empty string.
+
             try:
                 return convert_to(self.data.get(key, None))
             except ValueError:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,6 +98,23 @@ def mocked_data_empty_values_fixture():
         yield
 
 
+# This fixture, when used, will have the mocked values from response.json loaded in the integration.
+# As an addition, d2tmin and d2tmax have a wrong type (string instead of a number).
+@pytest.fixture(name="mocked_data_wrong_values_fixture")
+def mocked_data_wrong_values_fixture():
+    """Skip calls to get data from API."""
+    data = json.loads(load_fixture(response_json))
+
+    data["d2tmin"] = "koud"
+    data["d2tmax"] = "warm"
+
+    with patch(
+        async_get_data,
+        return_value=data,
+    ):
+        yield
+
+
 # In this fixture, we raise an KnmiApiClientCommunicationError in async_get_data.
 @pytest.fixture(name="error_on_get_data")
 def error_get_data_fixture():

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -44,7 +44,25 @@ async def test_get_value_empty(hass: HomeAssistant, mocked_data_empty_values, ca
     assert "Value plaats is missing in API response" in caplog.text
 
     coordinator.get_value("temp", int)
-    assert "Value temp can't be converted to <class 'int'>" in caplog.text
+    assert "Value temp is empty in API response" in caplog.text
+
+    assert await config_entry.async_unload(hass)
+    await hass.async_block_till_done()
+
+
+async def test_get_value_wrong_type(
+    hass: HomeAssistant, mocked_data_wrong_values_fixture, caplog
+):
+    """Test get_value function with empty values."""
+    config_entry = await setup_component(hass)
+
+    coordinator: KnmiDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
+
+    coordinator.get_value("d2tmin", int)
+    assert "Value d2tmin can't be converted to <class 'int'>" in caplog.text
+
+    coordinator.get_value("d2tmax", int)
+    assert "Value d2tmax can't be converted to <class 'int'>" in caplog.text
 
     assert await config_entry.async_unload(hass)
     await hass.async_block_till_done()


### PR DESCRIPTION
Will now log
```
Value d2tmin is empty in API response
```
Instead of trying to convert it, which logged:
```
Value d2tmin can't be converted to <class 'float'>
```