### PR TITLE
Make scan interval user configurable

### DIFF
--- a/custom_components/knmi/__init__.py
+++ b/custom_components/knmi/__init__.py
@@ -4,15 +4,24 @@ Custom integration to integrate knmi with Home Assistant.
 For more details about this integration, please refer to
 https://github.com/golles/ha-knmi/
 """
+from datetime import timedelta
+import logging
+
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE, Platform
+from homeassistant.const import (
+    CONF_API_KEY,
+    CONF_LATITUDE,
+    CONF_LONGITUDE,
+    CONF_SCAN_INTERVAL,
+    Platform,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
 
 from .api import KnmiApiClient
-from .const import API_CONF_URL, DOMAIN, NAME, VERSION
+from .const import API_CONF_URL, DEFAULT_SCAN_INTERVAL, DOMAIN, NAME, VERSION
 from .coordinator import KnmiDataUpdateCoordinator
 
 PLATFORMS: list[Platform] = [
@@ -20,6 +29,8 @@ PLATFORMS: list[Platform] = [
     Platform.SENSOR,
     Platform.WEATHER,
 ]
+
+_LOGGER: logging.Logger = logging.getLogger(__package__)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -29,9 +40,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     api_key = entry.data.get(CONF_API_KEY)
     latitude = entry.data.get(CONF_LATITUDE)
     longitude = entry.data.get(CONF_LONGITUDE)
+    scan_interval_seconds = entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+    scan_interval = timedelta(seconds=scan_interval_seconds)
 
     session = async_get_clientsession(hass)
     client = KnmiApiClient(api_key, latitude, longitude, session)
+
+    _LOGGER.debug(
+        "Set up entry, with scan_interval of %s seconds",
+        scan_interval_seconds,
+    )
 
     device_info = DeviceInfo(
         entry_type=DeviceEntryType.SERVICE,
@@ -43,7 +61,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
 
     hass.data[DOMAIN][entry.entry_id] = coordinator = KnmiDataUpdateCoordinator(
-        hass=hass, client=client, device_info=device_info
+        hass=hass,
+        client=client,
+        device_info=device_info,
+        scan_interval=scan_interval,
     )
 
     await coordinator.async_config_entry_first_refresh()

--- a/custom_components/knmi/config_flow.py
+++ b/custom_components/knmi/config_flow.py
@@ -2,7 +2,15 @@
 import logging
 
 from homeassistant import config_entries
-from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    CONF_API_KEY,
+    CONF_LATITUDE,
+    CONF_LONGITUDE,
+    CONF_NAME,
+    CONF_SCAN_INTERVAL,
+)
+from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
@@ -13,7 +21,7 @@ from .api import (
     KnmiApiClientCommunicationError,
     KnmiApiRateLimitError,
 )
-from .const import DOMAIN
+from .const import DEFAULT_SCAN_INTERVAL, DOMAIN
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
@@ -74,3 +82,47 @@ class KnmiFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         session = async_create_clientsession(self.hass)
         client = KnmiApiClient(api_key, latitude, longitude, session)
         await client.async_get_data()
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        return KnmiOptionsFlowHandler(config_entry)
+
+
+class KnmiOptionsFlowHandler(config_entries.OptionsFlow):
+    """Knmi config flow options handler."""
+
+    def __init__(self, config_entry: ConfigEntry):
+        """Initialize options flow."""
+        self.config_entry = config_entry
+        self.options = dict(config_entry.options)
+
+    async def async_step_init(self, user_input=None):  # pylint: disable=unused-argument
+        """Manage the options."""
+        return await self.async_step_user()
+
+    async def async_step_user(self, user_input=None):
+        """Handle a flow initialized by the user."""
+        if user_input is not None:
+            self.options.update(user_input)
+            return await self._update_options()
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_SCAN_INTERVAL,
+                        default=self.config_entry.options.get(
+                            CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+                        ),
+                    ): vol.All(vol.Coerce(int), vol.Range(min=300, max=86400))
+                }
+            ),
+        )
+
+    async def _update_options(self):
+        """Update config entry options."""
+        return self.async_create_entry(
+            title=self.config_entry.data.get(CONF_NAME), data=self.options
+        )

--- a/custom_components/knmi/const.py
+++ b/custom_components/knmi/const.py
@@ -1,5 +1,4 @@
 """Constants for knmi."""
-from datetime import timedelta
 from typing import Final
 
 # API
@@ -15,4 +14,4 @@ VERSION: Final = "1.6.1"
 
 # Defaults
 DEFAULT_NAME: Final = NAME
-SCAN_INTERVAL: timedelta = timedelta(seconds=300)
+DEFAULT_SCAN_INTERVAL: Final = 300

--- a/custom_components/knmi/coordinator.py
+++ b/custom_components/knmi/coordinator.py
@@ -1,4 +1,5 @@
 """DataUpdateCoordinator for knmi."""
+from datetime import timedelta
 import logging
 from typing import Any, Callable
 
@@ -8,7 +9,7 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .api import KnmiApiClient
-from .const import DOMAIN, SCAN_INTERVAL
+from .const import DOMAIN
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
@@ -19,14 +20,21 @@ class KnmiDataUpdateCoordinator(DataUpdateCoordinator):
     config_entry: ConfigEntry
 
     def __init__(
-        self, hass: HomeAssistant, client: KnmiApiClient, device_info: DeviceInfo
+        self,
+        hass: HomeAssistant,
+        client: KnmiApiClient,
+        device_info: DeviceInfo,
+        scan_interval: timedelta,
     ) -> None:
         """Initialize."""
         self.api = client
         self.device_info = device_info
 
         super().__init__(
-            hass=hass, logger=_LOGGER, name=DOMAIN, update_interval=SCAN_INTERVAL
+            hass=hass,
+            logger=_LOGGER,
+            name=DOMAIN,
+            update_interval=scan_interval,
         )
 
     async def _async_update_data(self) -> dict[str, Any]:

--- a/custom_components/knmi/translations/en.json
+++ b/custom_components/knmi/translations/en.json
@@ -17,5 +17,14 @@
       "daily_limit": "API key daily limit exceeded, try again tomorrow",
       "general": "Unknown error fetching weather data, try again later"
     }
+  },
+  "options": {
+    "step": {
+      "user": {
+        "data": {
+          "scan_interval": "Scan interval (seconds)"
+        }
+      }
+    }
   }
 }

--- a/custom_components/knmi/translations/nl.json
+++ b/custom_components/knmi/translations/nl.json
@@ -17,5 +17,14 @@
       "daily_limit": "De dagelijkse limiet van de API-sleutel is overschreden, probeer het morgen opnieuw",
       "general": "Onbekende fout bij het ophalen van weergegevens, probeer het later opnieuw"
     }
+  },
+  "options": {
+    "step": {
+      "user": {
+        "data": {
+          "scan_interval": "Scaninterval (seconden)"
+        }
+      }
+    }
   }
 }

--- a/tests/const.py
+++ b/tests/const.py
@@ -1,5 +1,11 @@
 """Constants for knmi tests."""
-from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
+from homeassistant.const import (
+    CONF_API_KEY,
+    CONF_LATITUDE,
+    CONF_LONGITUDE,
+    CONF_NAME,
+    CONF_SCAN_INTERVAL,
+)
 
 # Mock config data to be used across multiple tests
 MOCK_CONFIG = {
@@ -8,3 +14,5 @@ MOCK_CONFIG = {
     CONF_LONGITUDE: 4.763,
     CONF_NAME: "Home",
 }
+
+MOCK_UPDATE_CONFIG = {CONF_SCAN_INTERVAL: 600}


### PR DESCRIPTION
In the integration settings, the user can change the scan interval from the default 300 seconds (5 minutes) to anything between 5 minutes and 1 day.

300 is the minimum as the API allows 288 calls per day, this gives a few spare calls for restarts or integration reloads.

<img width="1009" alt="Scherm­afbeelding 2023-12-15 om 14 25 10" src="https://github.com/golles/ha-knmi/assets/2211503/5984c48f-2bb9-4bd4-8b8f-150e77d0b843">
