### PR TITLE
Suggestion to work around failed updates

### DIFF
--- a/custom_components/knmi/const.py
+++ b/custom_components/knmi/const.py
@@ -17,3 +17,5 @@ VERSION: Final = "2.0.1"
 # Defaults
 DEFAULT_NAME: Final = NAME
 DEFAULT_SCAN_INTERVAL: Final = 300
+# TODO by someone that understands HASS plugins better: make this user configurable, preferably in seconds rather than 'times'
+FAILED_UPDATES_ALLOWANCE: Final = 6

--- a/custom_components/knmi/coordinator.py
+++ b/custom_components/knmi/coordinator.py
@@ -55,14 +55,19 @@ class KnmiDataUpdateCoordinator(DataUpdateCoordinator):
             )
             # Do not throw an exception unless it's failed a few times to avoid excessive "unavailable" data
             # in HASS
-            if self.failed_update_count > FAILED_UPDATES_ALLOWANCE:
-                _LOGGER.error(
-                    "Update failed %s times, above limit of %s! - %s",
-                    self.failed_update_count,
-                    FAILED_UPDATES_ALLOWANCE,
-                    exception,
-                )
-                raise UpdateFailed() from exception
+            if self.failed_update_count <= FAILED_UPDATES_ALLOWANCE:
+                # return the 'old' data on a failed update
+                _LOGGER.debug("Update failed, returning existing data")
+                return self.data
+
+            # Data update failed too many times, raise an error
+            _LOGGER.error(
+                "Update failed %s times, above limit of %s! - %s",
+                self.failed_update_count,
+                FAILED_UPDATES_ALLOWANCE,
+                exception,
+            )
+            raise UpdateFailed() from exception
 
     def get_value(self, path: list[int | str], default=None) -> Any:
         """


### PR DESCRIPTION
Hi @golles, perhaps this could be an idea? Ideally the API is 'fixed' to return non-corrupt json, but there might be other reasons too why the API would not be available - i.e. we can't rely on the API always being there. To allow for that, we could implement something like this to ensure a single failed update does not turn the entities 'unavailable'.

I have this running with my own API key on a 'devcontainer-hass' now, I'll leave it running for a few hours to see if this has actually worked as expected. I have zero experience with HASS development, but my assumption is that the state of the integration's entities will only become 'unavailable' if an error is thrown. 

Ideally for me (and perhaps other users):

- I prefer 'stale' data (old data) over 'no data' ('unavailable), provided I can control how old the data can be;
- I would like to see how old the data is so that for "time critical" data I can perhaps deviate from the default (already provided by the integration via knmi_latest_update, so no change required).

**Note: treat this as a 'stub', should be expanded with tests etc, but unfortunately I'm not too familiar with HASS python coding and my VSCode IDE PyLance doesn't seem to pick up the installed requirements_dev packages, so no guarantee I will do that for now**

It seems to work so far.
As is, a 20 minute (2 failed updates) gap in the data:
![image](https://github.com/golles/ha-knmi/assets/3942301/e2f48bc1-0f61-4a2b-8650-5ae11f46f25c)

With this PR (I started up HASS around 09:06):
![image](https://github.com/golles/ha-knmi/assets/3942301/2a84bbb5-775a-4178-8bae-b767ed30c549)

