### PR TITLE
Add note about API key activation time

### DIFF
--- a/custom_components/knmi/translations/en.json
+++ b/custom_components/knmi/translations/en.json
@@ -13,7 +13,7 @@
       }
     },
     "error": {
-      "api_key": "The given API key is invalid",
+      "api_key": "The given API key is invalid. Note that it can take up to 5 minutes for new API keys to become active.",
       "daily_limit": "API key daily limit exceeded, try again tomorrow",
       "general": "Unknown error fetching weather data, try again later"
     }

--- a/custom_components/knmi/translations/nl.json
+++ b/custom_components/knmi/translations/nl.json
@@ -13,7 +13,7 @@
       }
     },
     "error": {
-      "api_key": "De opgegeven API-sleutel is ongeldig",
+      "api_key": "De opgegeven API-sleutel is ongeldig. Let op dat het 5 minuten kan duren voordat een nieuwe API key geldig is.",
       "daily_limit": "De dagelijkse limiet van de API-sleutel is overschreden, probeer het morgen opnieuw",
       "general": "Onbekende fout bij het ophalen van weergegevens, probeer het later opnieuw"
     }


### PR DESCRIPTION
This PR adds a note to the error message since KNMI API keys can take 5 minutes before they are active.