### PR TITLE
Clear persisted `sw_version`

### DIFF
--- a/custom_components/knmi/entity.py
+++ b/custom_components/knmi/entity.py
@@ -46,6 +46,7 @@ class KnmiEntity(CoordinatorEntity[KnmiDataUpdateCoordinator]):
             identifiers={(DOMAIN, coordinator.config_entry.entry_id)},
             manufacturer="Weerlive",
             name=coordinator.config_entry.data.get(CONF_NAME),
+            sw_version=None,
         )
 
     @property


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to the project!
  Please, DO NOT DELETE ANY TEXT from this template!
-->

## Proposed change

<!--
  Please include a summary of the changes and link to any related issues.
  Please also include relevant motivation and context.
  Add one of the following labels to the PR:
    - bugfix
    - ci
    - dependencies
    - dev-environment
    - documentation
    - enhancement
    - new-feature
-->
`sw_version` was removed from the `DeviceInfo` as the integration version is defined in the manifest.
Home Assistant persisted the previous version, which looks odd, as in some places version 3.x.x was shown, and in another place a 2.x.x

## Breaking change

<!--
  Does this PR introduce any breaking changes?
  What changes might users need to make in their application due to this PR?
  Add the breaking-change label to the PR.
-->

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
