### PR TITLE
Remove renovate-config-validator hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,11 +21,6 @@ repos:
         exclude: const.py
       - id: trailing-whitespace
 
-  - repo: https://github.com/renovatebot/pre-commit-hooks
-    rev: 41.135.5
-    hooks:
-      - id: renovate-config-validator
-
   # CI checks
   # The following tools are all installed locally, so there is no need to use remote repos.
   # The main reason is to not have to worry about version mismatch between the project and pre-commit.


### PR DESCRIPTION
Removed renovate-config-validator hook from pre-commit configuration.

<!--
  You are amazing! Thanks for contributing to the project!
  Please, DO NOT DELETE ANY TEXT from this template!
-->

## Proposed change

<!--
  Please include a summary of the changes and link to any related issues.
  Please also include relevant motivation and context.
  Add one of the following labels to the PR:
    - bugfix
    - ci
    - dependencies
    - dev-environment
    - documentation
    - enhancement
    - new-feature
-->

## Breaking change

<!--
  Does this PR introduce any breaking changes?
  What changes might users need to make in their application due to this PR?
  Add the breaking-change label to the PR.
-->

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix is effective or that my feature works
