### PR TITLE
Update weerlive-api to 0.2.4

### DIFF
--- a/custom_components/knmi/manifest.json
+++ b/custom_components/knmi/manifest.json
@@ -7,6 +7,6 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/golles/ha-knmi/issues",
   "loggers": ["weerlive", "custom_components.knmi"],
-  "requirements": ["weerlive-api==0.2.3"],
+  "requirements": ["weerlive-api==0.2.4"],
   "version": "0.0.0"
 }

--- a/custom_components/knmi/weather.py
+++ b/custom_components/knmi/weather.py
@@ -182,6 +182,9 @@ class KnmiWeather(KnmiEntity, WeatherEntity):
         forecasts: list[Forecast] = []
 
         for daily_forecast in self.coordinator.data.daily_forecast:
+            if daily_forecast.day is None:
+                continue
+
             forecast = Forecast(
                 condition=self.map_condition(daily_forecast.image),
                 datetime=daily_forecast.day.isoformat(),
@@ -205,6 +208,9 @@ class KnmiWeather(KnmiEntity, WeatherEntity):
         forecasts: list[Forecast] = []
 
         for hourly_forecast in self.coordinator.data.hourly_forecast:
+            if hourly_forecast.time is None:
+                continue
+
             forecast = Forecast(
                 condition=self.map_condition(hourly_forecast.image),
                 datetime=hourly_forecast.time.isoformat(),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
   "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "weerlive-api==0.2.3",
+    "weerlive-api==0.2.4",
     "homeassistant>=2026.0.0",
 ]
 
@@ -85,7 +85,7 @@ log_cli_level = "DEBUG"
 
 [tool.ruff]
 line-length = 150
-target-version = "py313"
+target-version = "py314"
 src = ["custom_components/knmi"]
 
 [tool.ruff.lint]

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -254,6 +254,40 @@ async def test_async_forecast_hourly(hass: HomeAssistant) -> None:  # pylint: di
 
 
 @pytest.mark.usefixtures("mocked_data")
+async def test_async_forecast_daily_skips_missing_day(hass: HomeAssistant) -> None:
+    """Daily forecast entries without a parsed day are skipped."""
+    config_entry = await setup_integration(hass)
+    coordinator: KnmiDataUpdateCoordinator = config_entry.runtime_data
+    description = KnmiWeatherDescription(key="weer")
+    weather = KnmiWeather(config_entry, coordinator, description)
+
+    coordinator.data.daily_forecast[0].day = None
+
+    forecast = await weather.async_forecast_daily()
+    assert forecast
+    assert len(forecast) == 4
+
+    await unload_integration(hass, config_entry)
+
+
+@pytest.mark.usefixtures("mocked_data")
+async def test_async_forecast_hourly_skips_missing_time(hass: HomeAssistant) -> None:
+    """Hourly forecast entries without a parsed time are skipped."""
+    config_entry = await setup_integration(hass)
+    coordinator: KnmiDataUpdateCoordinator = config_entry.runtime_data
+    description = KnmiWeatherDescription(key="weer")
+    weather = KnmiWeather(config_entry, coordinator, description)
+
+    coordinator.data.hourly_forecast[0].time = None
+
+    forecast = await weather.async_forecast_hourly()
+    assert forecast
+    assert len(forecast) == 23
+
+    await unload_integration(hass, config_entry)
+
+
+@pytest.mark.usefixtures("mocked_data")
 async def test_async_forecast_twice_daily(hass: HomeAssistant) -> None:
     """Test twice daily forecast."""
     config_entry = await setup_integration(hass)

--- a/uv.lock
+++ b/uv.lock
@@ -1024,7 +1024,7 @@ runhass = [
 [package.metadata]
 requires-dist = [
     { name = "homeassistant", specifier = ">=2026.0.0" },
-    { name = "weerlive-api", specifier = "==0.2.3" },
+    { name = "weerlive-api", specifier = "==0.2.4" },
 ]
 
 [package.metadata.requires-dev]
@@ -2825,7 +2825,7 @@ wheels = [
 
 [[package]]
 name = "weerlive-api"
-version = "0.2.3"
+version = "0.2.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -2833,9 +2833,9 @@ dependencies = [
     { name = "mashumaro" },
     { name = "orjson" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9c/3c/ac50f45589bd2cd713e7257898e506bb4c0986e733171a7cbec8b1afe6e8/weerlive_api-0.2.3.tar.gz", hash = "sha256:e65de16a246b29a135ea4f8e0ead69081aa763994d4cb8d8c4db9364830772d8", size = 65562, upload-time = "2025-11-25T11:28:30.806Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/95/6bbd9446e793fe2ab85c78cbfa8324807637db2161b0017c90878e1735d9/weerlive_api-0.2.4.tar.gz", hash = "sha256:7496b90ac7b76323204ed86e91e0ad4cf9988b30bcdf47f5ca8cfbf5ae70bbab", size = 76576, upload-time = "2026-06-14T18:45:02.732Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/f1/b843d0e9460c271606b6a9263e1659b40d289b7526efeea486711eb87977/weerlive_api-0.2.3-py3-none-any.whl", hash = "sha256:2b584f6c16f27761d39cf4a11ab4b1fb6174cb05b83b3d51fc0418eb56fe5e45", size = 7769, upload-time = "2025-11-25T11:28:29.051Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/79/6c03bb9125e6b4f9f9dd1146cfd589dd300289139f0251b5a7c862a0f04e/weerlive_api-0.2.4-py3-none-any.whl", hash = "sha256:4ff78e9d419d84f50e32c5f85816cea8b5d03f6d3143e681bc2b5dea4841dc20", size = 7892, upload-time = "2026-06-14T18:45:01.535Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Proposed change

Bump `weerlive-api` from `0.2.3` to `0.2.4`
([golles/python-weerlive#226](https://github.com/golles/python-weerlive/pull/226)).

That release is a type-annotation/consistency cleanup with no runtime/wire
behavior change in the API client. The one part that affects this integration
is that several model `datetime` fields are now correctly typed as `Optional`
(`DailyForecast.day`, `HourlyForecast.time`, and others). The forecast loops in
`weather.py` called `.isoformat()` directly on `day` / `time`, which now fails
type checking, so this PR guards against `None` by skipping forecast entries
without a parsed timestamp. This isn't a new runtime risk — those fields could
already be `None`; the annotations were simply wrong before.

Also aligns ruff's `target-version` to `py314` to match `requires-python` and
the upstream library, and adds tests covering the new skip branches (keeping
`weather.py` at 100% coverage).

Changes:
- Bump `weerlive-api==0.2.4` in `pyproject.toml`, `manifest.json`, and `uv.lock`.
- Skip daily/hourly forecast entries with a missing `day` / `time` in `weather.py`.
- Set ruff `target-version` to `py314`.
- Add `test_async_forecast_daily_skips_missing_day` and
  `test_async_forecast_hourly_skips_missing_time`.

Label: `dependencies`

## Breaking change

No. No user-facing or configuration changes. The renamed upstream exception
(`WeerliveDecodeError` -> `WeerliveAPIDecodeError`) is not referenced anywhere
in this integration, so no changes were needed for it.

## Checklist:

- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective or that my feature works